### PR TITLE
tailwind.config.js fix to prevent clobbering media query-based classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ module.exports = {
   mode: 'jit',
   darkMode: "class",
   content: ["./resources/**/*.{js,vue}"],
+  blocklist: [
+    'flex', 'inline-flex', 'inline', 'flex-shrink-0'
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Because action-buttons css is loaded after the Nova's, redefinition of, e.g. .flex, clobbers / overrides .md:hidden.

<img width="590" alt="Screenshot 2025-02-09 at 17 06 58" src="https://github.com/user-attachments/assets/5bc382cf-73c3-480f-9062-93246dbf01d2" />

<img width="461" alt="Screenshot 2025-02-09 at 17 09 28" src="https://github.com/user-attachments/assets/a8cf5d3d-e0a3-4578-a22a-bd5e7404e36b" />
